### PR TITLE
Use node-ssdp 0.2.0 to make bunyan dependencies optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/iceddev/dial/issues"
   },
   "dependencies": {
-    "node-ssdp": "0.1.1",
+    "node-ssdp": "0.2.0",
     "rest": "~0.9.3",
     "xml2json": "~0.3.2"
   }


### PR DESCRIPTION
With the latest version of Node (v0.11.x), various C++ extensions break due to a direct dependency on a V8 HandleScope. node-ssdp has a dependency on bunyan which has a dependency on dtrace-provider which breaks the install process for this extension on newer versions of node.

The latest versions of node-ssdp and bunyan make dtrace-provider optional which allows the install to continue.
